### PR TITLE
fix: remove near-zero weights after subtraction to keep vertex groups clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve merge performance for meshes with many vertices
 - Improve internal stability of object tracking and timer handling
+- Remove near-zero weights (< 0.000001) after subtraction to keep vertex groups clean
 
 ### 修正
 
@@ -33,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 頂点数の多いメッシュでのマージ性能を改善
 - オブジェクト追跡とタイマー処理の内部安定性を向上
+- 減算時にゼロに近い微小ウェイト（0.000001未満）を自動削除し、頂点グループをクリーンに保つように
 
 ## [0.4.0] - 2025-06-26
 

--- a/__init__.py
+++ b/__init__.py
@@ -205,6 +205,8 @@ class MESH_OT_merge_vertex_groups(Operator):
                 weight = target_weight - source_sum
 
             weight = max(0.0, weight)
+            if operation_mode == "SUBTRACT" and weight < 1e-6:
+                weight = 0.0
             if maintain_total_weight and weight > 1.0:
                 weight = 1.0
 


### PR DESCRIPTION
## Summary

- Remove near-zero vertex weights (< 0.000001) after subtraction to keep vertex groups clean
- Previously, extremely small weights like `0.000001` would remain in the vertex group after subtraction, even though they have no visible effect

## 概要

- 減算後にゼロに近い微小ウェイト（0.000001未満）を自動的に削除し、頂点グループをクリーンに保つように改善
- これまでは減算後に `0.000001` のような極小ウェイトが頂点グループに残り続けていたが、実質的に影響がないため削除するように変更