### PR TITLE
fix: disable merge button in Edit Mode to prevent errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Disable merge button in Edit Mode to prevent errors
 - Fix error when merging after vertex groups are externally deleted or renamed
 - Fix source groups list not updating when vertex groups are added, deleted, or renamed on the same object
 - Fix last vertex group being incorrectly highlighted when changing target group while in range selection mode
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 修正
 
+- 編集モード中にマージボタンを無効化し、エラーを防止
 - 頂点グループが外部で削除・リネームされた後にマージするとエラーになる問題を修正
 - 同一オブジェクト上で頂点グループを追加・削除・リネームしてもソースグループ一覧が更新されない問題を修正
 - 範囲選択モード中にマージ先グループを変更すると、最後の頂点グループが選択状態になる問題を修正

--- a/__init__.py
+++ b/__init__.py
@@ -43,7 +43,12 @@ class MESH_OT_merge_vertex_groups(Operator):
     @classmethod
     def poll(cls, context) -> bool:
         obj = context.active_object
-        return obj and obj.type == "MESH" and len(obj.vertex_groups) > 1
+        return (
+            obj
+            and obj.type == "MESH"
+            and obj.mode != "EDIT_MESH"
+            and len(obj.vertex_groups) > 1
+        )
 
     def execute(self, context) -> Set[str]:
         obj: Object = context.active_object


### PR DESCRIPTION
- Disable the merge button when the active object is in Edit Mode, preventing runtime errors that occurred when attempting to merge vertex groups in Edit Mode
- 編集モード中にマージボタンを無効化し、編集モードでマージ実行時に発生するエラーを防止