### PR TITLE
feat: add "+" button to create target vertex group from panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add "+" button next to target group selector to create a new vertex group directly from the panel
+
 ### Fixed
 
 - Disable merge button in Edit Mode to prevent errors
@@ -24,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve merge performance for meshes with many vertices
 - Improve internal stability of object tracking and timer handling
 - Remove near-zero weights (< 0.000001) after subtraction to keep vertex groups clean
+
+### 追加
+
+- マージ先グループの横に「+」ボタンを追加し、パネルから直接新しい頂点グループを作成可能に
 
 ### 修正
 

--- a/__init__.py
+++ b/__init__.py
@@ -330,12 +330,59 @@ class MESH_OT_apply_range_selection(Operator):
         return {"FINISHED"}
 
 
+def generate_vertex_group_name(obj) -> str:
+    """Generate a default vertex group name following Blender's naming convention."""
+    base = "Group"
+    names = {vg.name for vg in obj.vertex_groups}
+    if base not in names:
+        return base
+    i = 1
+    while f"{base}.{i:03d}" in names:
+        i += 1
+    return f"{base}.{i:03d}"
+
+
+class MESH_OT_add_target_vertex_group(Operator):
+    """Add a new vertex group and set it as the merge target"""
+
+    bl_idname = "mesh.add_target_vertex_group"
+    bl_label = "Add Target Vertex Group"
+    bl_options = {"REGISTER", "UNDO"}
+
+    group_name: StringProperty(
+        name="Name",
+        description="Name of the new vertex group",
+        default="",
+    )
+
+    @classmethod
+    def poll(cls, context) -> bool:
+        obj = context.active_object
+        return obj is not None and obj.type == "MESH"
+
+    def invoke(self, context, event) -> Set[str]:
+        self.group_name = generate_vertex_group_name(context.active_object)
+        return context.window_manager.invoke_props_dialog(self)
+
+    def execute(self, context) -> Set[str]:
+        obj = context.active_object
+        settings = context.scene.vertex_group_merger
+
+        name = self.group_name.strip()
+        if not name:
+            name = generate_vertex_group_name(obj)
+        vg = obj.vertex_groups.new(name=name)
+        settings.target_group = vg.name
+
+        return {"FINISHED"}
+
+
 class MESH_OT_update_source_groups_list(Operator):
     """Update source groups list safely"""
 
     bl_idname = "mesh.update_source_groups_list"
     bl_label = "Update Source Groups List"
-    bl_options = {"REGISTER", "UNDO", "INTERNAL"}
+    bl_options = {"INTERNAL"}
 
     def execute(self, context) -> Set[str]:
         # Reset range selection state and update source groups list
@@ -593,7 +640,7 @@ class VIEW3D_PT_vertex_group_merger(Panel):
                 bpy.app.timers.register(reset_range_mode, first_interval=0.01)
 
         # Target group selection
-        row = layout.row()
+        row = layout.row(align=True)
         row.prop_search(
             settings,
             "target_group",
@@ -601,6 +648,7 @@ class VIEW3D_PT_vertex_group_merger(Panel):
             "vertex_groups",
             text=bpy.app.translations.pgettext("Target Group"),
         )
+        row.operator("mesh.add_target_vertex_group", text="", icon="ADD")
 
         # Operation mode selection
         row = layout.row()
@@ -704,6 +752,7 @@ classes: List[Any] = [
     MESH_UL_merge_source_groups,
     MESH_OT_update_source_groups_list,
     MESH_OT_apply_range_selection,
+    MESH_OT_add_target_vertex_group,
     VertexGroupMergerSettings,
     MESH_OT_merge_vertex_groups,
     VIEW3D_PT_vertex_group_merger,

--- a/translations.py
+++ b/translations.py
@@ -35,6 +35,11 @@ translations_dict = {
         # Error messages
         ("*", "Target group not found"): "マージ先グループが見つかりません",
         ("*", "No source groups selected"): "マージ元グループが選択されていません",
+        # Add target vertex group operator
+        ("*", "Add a new vertex group and set it as the merge target"): "新しい頂点グループを追加してマージ先に設定",
+        ("*", "Add Target Vertex Group"): "マージ先頂点グループを追加",
+        ("Operator", "Add Target Vertex Group"): "マージ先頂点グループを追加",
+        ("*", "Name of the new vertex group"): "新しい頂点グループの名前",
         
         # Success messages (complete sentences with placeholders)
         ("*", "Groups {source} merged into {target}"): "{source}を{target}にマージしました",


### PR DESCRIPTION
## Summary
- Add a "+" button next to the target group selector to create a new vertex group directly from the merge panel
- Clicking "+" opens a naming dialog with Blender's default naming convention ("Group", "Group.001", ...), and sets the new group as the merge target
- Remove unnecessary UNDO flag from internal `MESH_OT_update_source_groups_list` operator

## 概要
- マージ先グループのセレクター横に「+」ボタンを追加し、パネルから直接新しい頂点グループを作成可能に
- 「+」クリックでBlender標準の命名規則（"Group", "Group.001", ...）に従ったデフォルト名のダイアログが表示され、確定後にマージ先として自動設定
- 内部オペレーター `MESH_OT_update_source_groups_list` から不要な UNDO フラグを削除